### PR TITLE
add tf_prefix for robot_state_publisher

### DIFF
--- a/gazebo/robot_assembler_gazebo_robot.launch
+++ b/gazebo/robot_assembler_gazebo_robot.launch
@@ -48,7 +48,9 @@
 
     <!-- convert joint states to TF transforms -->
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"
-          respawn="false" output="screen" />
+          respawn="false" output="screen">
+          <param if="$(arg use_namespace)" name="tf_prefix" value="$(arg namespace)" />
+    </node>
 
     <!-- load the controllers -->
     <node name="controller_spawner" pkg="controller_manager"


### PR DESCRIPTION
SAMPLE_HUMANOIDの例で2つのロボットのtfの名前が衝突していたので，tf_prefixをつけるようにしました．