### PR TITLE
use B8G8R8

### DIFF
--- a/gazebo/gazebo_plugins.xacro
+++ b/gazebo/gazebo_plugins.xacro
@@ -104,7 +104,7 @@
           <image>
             <width>${width}</width>
             <height>${height}</height>
-            <format>R8G8B8</format>
+            <format>B8G8R8</format>
           </image>
           <clip>
             <near>0.02</near>


### PR DESCRIPTION
related to https://github.com/ros-simulation/gazebo_ros_pkgs/issues/484

RGB point cloud seems not correctly working with `R8G8B8`
(see https://github.com/ros-simulation/gazebo_ros_pkgs/issues/484)
I switch to use `B8G8R8` to publish correctly.

- Before `B8G8R8`
![Screenshot from 2020-08-10 05-22-00](https://user-images.githubusercontent.com/42209144/89741151-da103b80-dac9-11ea-99dd-a931185334fe.png)

- After `R8G8B8`
![Screenshot from 2020-08-10 05-23-59](https://user-images.githubusercontent.com/42209144/89741155-e7c5c100-dac9-11ea-843b-6df39d4c3bf2.png)

cc. @knorth55